### PR TITLE
fix(notification): log exception on failure

### DIFF
--- a/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.java
+++ b/echo-core/src/main/java/com/netflix/spinnaker/echo/notification/AbstractEventNotificationAgent.java
@@ -126,7 +126,7 @@ public abstract class AbstractEventNotificationAgent implements EventListener {
           try {
             sendNotifications(notification, application, event, config, status);
           } catch (Exception e) {
-            log.error("failed to send {} message", getNotificationType());
+            log.error("failed to send {} message", getNotificationType(), e);
           }
         });
   }


### PR DESCRIPTION
This change updates the logging so that when a notification agent fails the exception is logged.